### PR TITLE
Parse scores and display player levels in player list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ function App() {
                     selectedPlayer={selectedPlayer}
                     selectPlayer={actions.selectPlayer}
                     currentStep={gameStep}
+                    timeline={game.timeline}
                   />
                 </Stack>
               </Tab>

--- a/src/PlayerList.tsx
+++ b/src/PlayerList.tsx
@@ -18,9 +18,13 @@ function PlayerList({
   timeline,
 }: PlayerListProps): JSX.Element {
   const { metrics } = timeline[currentStep];
+  // TODO: Toggle sorting by kills / score / default?
+  const sortedPlayers = [...players].sort(
+    (a, b) => metrics[b.index].score - metrics[a.index].score
+  );
   return (
     <ListGroup>
-      {players.map((player) => (
+      {sortedPlayers.map((player) => (
         <PlayerListItem
           key={player.index}
           player={player}
@@ -50,6 +54,7 @@ function PlayerListItem({
   metrics,
   selectPlayer,
 }: PlayerListItemProps): JSX.Element {
+  const killIndicator = "⚔".repeat(metrics.kills);
   return (
     <ListGroup.Item
       className={`d-flex flex-row align-items-center p-1`}
@@ -60,7 +65,7 @@ function PlayerListItem({
       <LetterCell letter="a" owner={isDead ? undefined : player} />
       <Metrics metrics={metrics} />
       <div className="ms-2">
-        {player.name} {Array(metrics.kills).fill("⚔").join("")}
+        {player.name} {killIndicator}
       </div>
     </ListGroup.Item>
   );

--- a/src/PlayerList.tsx
+++ b/src/PlayerList.tsx
@@ -1,3 +1,4 @@
+import Badge from "react-bootstrap/Badge";
 import ListGroup from "react-bootstrap/ListGroup";
 import { DEAD_SCORE } from "./constants";
 import { LetterCell } from "./GameGrid";
@@ -72,10 +73,15 @@ function PlayerListItem({
   );
 }
 
-const Metrics = ({ metrics: { score } }: { metrics: PlayerMetrics }) => (
-  <div style={{ marginLeft: "8px", width: "20px", textAlign: "center" }}>
-    {score === DEAD_SCORE ? "☠" : levelFromScore(score)}
-  </div>
-);
+const Metrics = ({ metrics: { score } }: { metrics: PlayerMetrics }) => {
+  const dead = score === DEAD_SCORE;
+  return (
+    <div className="ms-3">
+      <Badge bg={dead ? "light" : "dark"}>
+        {dead ? "☠" : levelFromScore(score)}
+      </Badge>
+    </div>
+  );
+};
 
 export default PlayerList;

--- a/src/PlayerList.tsx
+++ b/src/PlayerList.tsx
@@ -1,30 +1,34 @@
 import ListGroup from "react-bootstrap/ListGroup";
+import { DEAD_SCORE } from "./constants";
 import { LetterCell } from "./GameGrid";
-import { PlayerDetails } from "./types";
+import { Game, PlayerDetails, PlayerMetrics } from "./types";
 
 interface PlayerListProps {
   players: PlayerDetails[];
   selectedPlayer: number | null;
   selectPlayer: (player: number | null) => void;
   currentStep: number;
+  timeline: Game["timeline"];
 }
 function PlayerList({
   players,
   selectedPlayer,
   selectPlayer,
   currentStep,
+  timeline,
 }: PlayerListProps): JSX.Element {
+  const { metrics } = timeline[currentStep];
   return (
     <ListGroup>
-      {players.map((player, i) => (
+      {players.map((player) => (
         <PlayerListItem
-          key={i}
+          key={player.index}
           player={player}
           isDead={
             player.killedStep !== null && currentStep >= player.killedStep
           }
-          isSelected={selectedPlayer === i}
-          index={i}
+          isSelected={selectedPlayer === player.index}
+          metrics={metrics[player.index]}
           selectPlayer={selectPlayer}
         />
       ))}
@@ -34,31 +38,38 @@ function PlayerList({
 
 interface PlayerListItemProps {
   player: PlayerDetails;
-  index: number;
   isDead: boolean;
   isSelected: boolean;
+  metrics: PlayerMetrics;
   selectPlayer: (player: number | null) => void;
 }
 function PlayerListItem({
   player,
-  index,
   isDead,
   isSelected,
+  metrics,
   selectPlayer,
 }: PlayerListItemProps): JSX.Element {
   return (
     <ListGroup.Item
       className={`d-flex flex-row align-items-center p-1`}
-      onClick={() => selectPlayer(isSelected ? null : index)}
+      onClick={() => selectPlayer(isSelected ? null : player.index)}
       action
       active={isSelected}
     >
       <LetterCell letter="a" owner={isDead ? undefined : player} />
+      <Metrics metrics={metrics} />
       <div className="ms-2">
-        {player.name} {isDead && "☠"}
+        {player.name} {Array(metrics.kills).fill("⚔").join("")}
       </div>
     </ListGroup.Item>
   );
 }
+
+const Metrics = ({ metrics: { score } }: { metrics: PlayerMetrics }) => (
+  <div style={{ width: "40px", textAlign: "center" }}>
+    {score === DEAD_SCORE ? "☠" : score}
+  </div>
+);
 
 export default PlayerList;

--- a/src/PlayerList.tsx
+++ b/src/PlayerList.tsx
@@ -2,6 +2,7 @@ import ListGroup from "react-bootstrap/ListGroup";
 import { DEAD_SCORE } from "./constants";
 import { LetterCell } from "./GameGrid";
 import { Game, PlayerDetails, PlayerMetrics } from "./types";
+import levelFromScore from "./utils/level-from-score";
 
 interface PlayerListProps {
   players: PlayerDetails[];
@@ -72,8 +73,8 @@ function PlayerListItem({
 }
 
 const Metrics = ({ metrics: { score } }: { metrics: PlayerMetrics }) => (
-  <div style={{ width: "40px", textAlign: "center" }}>
-    {score === DEAD_SCORE ? "☠" : score}
+  <div style={{ marginLeft: "8px", width: "20px", textAlign: "center" }}>
+    {score === DEAD_SCORE ? "☠" : levelFromScore(score)}
   </div>
 );
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEAD_SCORE = -7347;

--- a/src/placeholder-game.ts
+++ b/src/placeholder-game.ts
@@ -1,3 +1,4 @@
+import { emptyMetrics } from "./parser";
 import {
   Letter,
   PlayerName,
@@ -55,7 +56,7 @@ const placeholderGame: Game = {
         money: 42,
         points: 801,
       },
-      scores: [],
+      metrics: emptyMetrics,
     },
   ],
   kills: [],

--- a/src/placeholder-game.ts
+++ b/src/placeholder-game.ts
@@ -55,6 +55,7 @@ const placeholderGame: Game = {
         money: 42,
         points: 801,
       },
+      scores: [],
     },
   ],
   kills: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,11 @@ export type Bonus = Item | "2x_word" | "3x_word" | "3x_letter" | "5x_letter";
 
 type SparseArray<T> = Array<T | void>;
 
+export interface PlayerMetrics {
+  score: number;
+  kills: number;
+}
+
 export type GameStep = {
   letters: SparseArray<Letter>;
   owners: SparseArray<PlayerIndex>;
@@ -98,7 +103,7 @@ export type GameStep = {
     words: string[];
   };
   hot: SparseArray<HotZone>;
-  scores: Array<number>;
+  metrics: Array<PlayerMetrics>;
 };
 
 export type Game = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export type GameStep = {
     words: string[];
   };
   hot: SparseArray<HotZone>;
+  scores: Array<number>;
 };
 
 export type Game = {

--- a/src/utils/level-from-score.ts
+++ b/src/utils/level-from-score.ts
@@ -1,0 +1,16 @@
+const XP_REQUIRED = [
+  0, 10, 30, 70, 110, 160, 200, 250, 320, 380, 460, 600, 800, 1050, 1300, 1600,
+  1950, 2350, 2800, 3300, 3900, 4600, 5600, 6900, 8900, 11000, 14000, 17000,
+  21000, 26000, 32000, 40000,
+];
+
+const levelFromScore = (score: number) => {
+  for (let i = 0; i < XP_REQUIRED.length; i++) {
+    if (score < XP_REQUIRED[i]) {
+      return i;
+    }
+  }
+  return XP_REQUIRED.length;
+};
+
+export default levelFromScore;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3461433/150047587-8f54c5bd-9d15-4039-8eab-6f8663051328.png)

In this PR, we parse player scores from the `SyncNewBoardState` event, store them (alongside kills) in a new `metrics` key on `GameStep`, and display kills and level on the player list. There's also a small refactor to use the parsed score when displaying whether each player is dead or alive.

This PR sits on top of the `display-death-state` PR - if you like I can pull that out and just use the stuff in here instead.

TODO: Make the level display less boring