### PR TITLE
Allow the import of multiple log files in one zip

### DIFF
--- a/src/Importer.tsx
+++ b/src/Importer.tsx
@@ -49,7 +49,7 @@ function Importer({ show, onImport, onClose }: ImportProps): JSX.Element {
       blobs = [file];
     }
 
-    for (let blob of blobs){
+    for (let blob of blobs) {
       const parser = newParser();
       // The type cast is required because @types/node messes with the DOM type
       // See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58079

--- a/src/Importer.tsx
+++ b/src/Importer.tsx
@@ -35,33 +35,40 @@ function Importer({ show, onImport, onClose }: ImportProps): JSX.Element {
   async function parseFile(file: File) {
     setLoading(true);
 
+    let blobs: Array<Blob> = [];
+    let games: Array<Game> = [];
+
     let blob: Blob = file;
     if (file.name.endsWith(".zip")) {
       const reader = new zip.ZipReader(new zip.BlobReader(blob));
       const entries = await reader.getEntries();
-      if (entries.length !== 1) {
-        return setError("Zip files should contain only one log file.");
+      for (let entry of entries) {
+        blobs.push(await entry.getData!(new zip.BlobWriter()));
       }
-      blob = await entries[0].getData!(new zip.BlobWriter());
+    } else {
+      blobs = [file];
     }
 
-    const parser = newParser();
-    // The type cast is required because @types/node messes with the DOM type
-    // See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58079
-    const stream = blob.stream() as any as ReadableStream<Uint8Array>;
-    const reader = stream.getReader();
-    const utf8Decoder = new TextDecoder("utf-8");
-    while (true) {
-      let { value, done } = await reader.read();
-      const chunk = utf8Decoder.decode(value, { stream: !done });
-      parser.parse(chunk);
-      if (done) break;
-    }
-    parser.end();
+    for (let blob of blobs){
+      const parser = newParser();
+      // The type cast is required because @types/node messes with the DOM type
+      // See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58079
+      const stream = blob.stream() as any as ReadableStream<Uint8Array>;
+      const reader = stream.getReader();
+      const utf8Decoder = new TextDecoder("utf-8");
+      while (true) {
+        let { value, done } = await reader.read();
+        const chunk = utf8Decoder.decode(value, { stream: !done });
+        parser.parse(chunk);
+        if (done) break;
+      }
+      parser.end();
 
-    const games = parser.games();
+      games.push(...parser.games());
+    }
+
     if (games.length === 0) {
-      return setError("No games found in log file. Try another file.");
+      return setError("No games found in this file. Try another file.");
     }
 
     setTimeout(() => {
@@ -114,8 +121,8 @@ function Importer({ show, onImport, onClose }: ImportProps): JSX.Element {
               </p>
               <p>
                 If you want to keep a lot of files and save some space, you can
-                compress them into <code>.zip</code> files, each containing a
-                single log - and these will also be accepted.
+                compress them into <code>.zip</code> files and these will also
+                be accepted.
               </p>
               <p>
                 The file will not be uploaded to any server, all processing


### PR DESCRIPTION
* Closes #27 

This PR changes the zip file handling logic from opening only the first file to opening all of the files in that zip. 