### PR TITLE
Force bonus letter tiles onto new line

### DIFF
--- a/src/Game.module.css
+++ b/src/Game.module.css
@@ -18,7 +18,7 @@
 
 .bonusMultiplier {
   composes: empty;
-  line-height: 10px;
+  line-height: 12px;
   font-size: 75%;
 }
 
@@ -29,7 +29,7 @@
 
 .bonusLetter {
   composes: bonusMultiplier;
-  color: #9c9;
+  color: #393;
 }
 
 .bonusItem {

--- a/src/GameGrid.tsx
+++ b/src/GameGrid.tsx
@@ -121,11 +121,23 @@ const bonusTypeMap = {
   reroll_all: "bonusItem",
   letter_s: "bonusItem",
 } as const;
+interface ContentProps {
+  multiplier: Number;
+  bonusType: string;
+}
+function BonusCellContent({ multiplier, bonusType }: ContentProps) {
+  return (
+    <>
+      {multiplier.toString()}x<br />
+      {bonusType}
+    </>
+  );
+}
 const bonusContentMap = {
-  "2x_word": "2x Wd",
-  "3x_word": "3x Wd",
-  "3x_letter": "3x Lt",
-  "5x_letter": "5x Lt",
+  "2x_word": <BonusCellContent multiplier={2} bonusType={"Wd"} />,
+  "3x_word": <BonusCellContent multiplier={3} bonusType={"Wd"} />,
+  "3x_letter": <BonusCellContent multiplier={3} bonusType={"Lt"} />,
+  "5x_letter": <BonusCellContent multiplier={5} bonusType={"Lt"} />,
   bomb: "💣",
   medkit: "➕",
   reroll_all: "♺",


### PR DESCRIPTION
This PR changes the bonus tile text from relying on word wrap to using `<br>`. Also in this PR is some CSS changes

Before:

![Before](https://i.imgur.com/TRVfSxq.png)

After:

![After](https://i.imgur.com/XydrJWl.png)