### PR TITLE
Change the letter next to player name to be their starting letter instead of "A"

### DIFF
--- a/src/PlayerList.tsx
+++ b/src/PlayerList.tsx
@@ -64,7 +64,10 @@ function PlayerListItem({
       action
       active={isSelected}
     >
-      <LetterCell letter="a" owner={isDead ? undefined : player} />
+      <LetterCell
+        letter={player.startingLetter}
+        owner={isDead ? undefined : player}
+      />
       <Metrics metrics={metrics} />
       <div className="ms-2">
         {player.name} {killIndicator}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -230,6 +230,7 @@ export function newParser() {
     SyncNewBoardState({ squaresWithLetters, playerScores }) {
       if (startIndex !== undefined && game.you.name === "") {
         identifyPlayerOne(squaresWithLetters);
+        getStartingLetters(squaresWithLetters);
       }
 
       const letters: GameStep["letters"] = [];
@@ -473,6 +474,17 @@ export function newParser() {
     game.you.name = game.players[0].name;
   }
 
+  function getStartingLetters(
+    squares: Events["SyncNewBoardState"]["squaresWithLetters"]
+  ) {
+    game.players.forEach((player) => {
+      const startingSquare = squares.find(
+        ({ playerLivingOn }) => playerLivingOn === player.socketID
+      );
+      player.startingLetter = startingSquare?.letter || "a";
+    });
+  }
+
   let buffer = "";
   function handleLine(line: string) {
     if (line[0] !== "[" || line[1] !== '"') return;
@@ -508,12 +520,15 @@ const isGameMalformed = (game: Game) => {
   return game.timeline.length === 0;
 };
 
-function indexPlayers(players: Omit<PlayerDetails, "index" | "killedStep">[]) {
+function indexPlayers(
+  players: Omit<PlayerDetails, "index" | "killedStep" | "startingLetter">[]
+) {
   return players.map(({ name, socketID }, index) => ({
     socketID,
     name,
     index: playerIndex(index),
     killedStep: null,
+    startingLetter: "a" as Letter,
   }));
 }
 

--- a/src/placeholder-game.ts
+++ b/src/placeholder-game.ts
@@ -30,6 +30,7 @@ const players: PlayerDetails[] = [
   socketID: ("xx_" + name) as SocketID,
   index: i as PlayerIndex,
   killedStep: null,
+  startingLetter: i % 2 === 0 ? "a" : "i",
 }));
 
 const placeholderGame: Game = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export type PlayerDetails = {
   socketID: SocketID;
   index: PlayerIndex;
   killedStep: number | null;
+  startingLetter: Letter;
 };
 
 interface KillBase {


### PR DESCRIPTION
This PR changes the parser to use the first board state to figure out what the starting letter of each player was, then assign that to each player. The starting letter is then shown it the player listing.

Before:

![Before](https://i.imgur.com/jSN2YVD.png)

After:

![After](https://i.imgur.com/BvYOfxH.png)

~~As a bonus, placeholder game is changed to be AIAIA~~