### PR TITLE
Sort dead players by when they died

### DIFF
--- a/src/PlayerList.tsx
+++ b/src/PlayerList.tsx
@@ -21,9 +21,13 @@ function PlayerList({
 }: PlayerListProps): JSX.Element {
   const { metrics } = timeline[currentStep];
   // TODO: Toggle sorting by kills / score / default?
-  const sortedPlayers = [...players].sort(
-    (a, b) => metrics[b.index].score - metrics[a.index].score
+  const alivePlayers = players.filter(
+    (a) => metrics[a.index].score !== DEAD_SCORE
   );
+  const deadPlayers = players.filter((a) => !alivePlayers.includes(a));
+  alivePlayers.sort((a, b) => metrics[b.index].score - metrics[a.index].score);
+  deadPlayers.sort((a, b) => (b.killedStep ?? 0) - (a.killedStep ?? 0));
+  const sortedPlayers = [...alivePlayers, ...deadPlayers];
   return (
     <ListGroup>
       {sortedPlayers.map((player) => (

--- a/src/PlayerList.tsx
+++ b/src/PlayerList.tsx
@@ -21,13 +21,11 @@ function PlayerList({
 }: PlayerListProps): JSX.Element {
   const { metrics } = timeline[currentStep];
   // TODO: Toggle sorting by kills / score / default?
-  const alivePlayers = players.filter(
-    (a) => metrics[a.index].score !== DEAD_SCORE
-  );
-  const deadPlayers = players.filter((a) => !alivePlayers.includes(a));
-  alivePlayers.sort((a, b) => metrics[b.index].score - metrics[a.index].score);
-  deadPlayers.sort((a, b) => (b.killedStep ?? 0) - (a.killedStep ?? 0));
-  const sortedPlayers = [...alivePlayers, ...deadPlayers];
+  const sortedPlayers = [...players].sort((a, b) => {
+    const diff = metrics[b.index].score - metrics[a.index].score;
+    if (diff !== 0) return diff;
+    return (b.killedStep ?? Infinity) - (a.killedStep ?? Infinity);
+  });
   return (
     <ListGroup>
       {sortedPlayers.map((player) => (


### PR DESCRIPTION
This PR changes the way players are sorted in listing from only using score (which is same for all dead players) to also using when someone died.