### PR TITLE
Sort imported games based on when they were played

### DIFF
--- a/src/Importer.tsx
+++ b/src/Importer.tsx
@@ -52,7 +52,9 @@ function Importer({ show, onImport, onClose }: ImportProps): JSX.Element {
 
     if (file.name.endsWith(".zip")) {
       const reader = new zip.ZipReader(new zip.BlobReader(file));
-      const entries = await reader.getEntries();
+      const entries = Array.from(await reader.getEntries()).sort(
+        (a, b) => a.rawLastModDate - b.rawLastModDate
+      );
       for (let entry of entries) {
         await parseBlob(await entry.getData!(new zip.BlobWriter()));
       }


### PR DESCRIPTION
Now that zip files can have multiple logs in them, the parsed games aren't guaranteed to be sorted. This PR sorts the games after importing them. `a.id - b.id` is used because that results in newest games being at the bottom (which seemed to be the default before)