### PR TITLE
Spike: render the grid with SVG elements

### DIFF
--- a/src/Game.module.css
+++ b/src/Game.module.css
@@ -2,6 +2,40 @@
   margin: 1px;
 }
 
+.cellSVG {
+  cursor: default;
+  --cell-bg: #eee;
+  --cell-fg: #eee;
+}
+.cellSVG :global(rect) {
+  fill: var(--cell-bg);
+}
+.cellSVG :global(text) {
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  font-size: 1rem;
+  font-weight: 400;
+  fill: var(--cell-fg);
+}
+
+.emptySVG {
+  composes: cellSVG;
+}
+
+.letterSVG {
+  composes: cellSVG;
+  --cell-bg: #777;
+  --cell-fg: #eee;
+}
+.highlight {
+  filter: drop-shadow(0 0 8px var(--cell-bg));
+}
+
+.bonusSVG {
+  composes: cellSVG;
+}
+
 .cell {
   width: 25px;
   height: 25px;

--- a/src/GameGrid.tsx
+++ b/src/GameGrid.tsx
@@ -1,5 +1,7 @@
-import { Bonus, Letter, Game, PlayerDetails, HotZone } from "./types";
+import { Bonus, Letter, Game, PlayerDetails } from "./types";
 import styles from "./Game.module.css";
+
+const CELL_SIZE = 25;
 
 interface GameGridProps {
   game: Game;
@@ -16,56 +18,112 @@ export default function GameGrid({
   const size = game.board.size;
   const range = Array(size).fill(0);
   const state = game.timeline[currentStep];
-  return (
-    <table cellSpacing={0} cellPadding={0} className={styles.board}>
-      <tbody>
-        {range.map((_, row) => (
-          <tr key={row}>
-            {range.map((_, col) => {
-              const index = row * size + col;
-              const letter = state.letters[index];
-              const owner = state.owners[index];
-              const hot = state.hot[index];
-              const bombed = state.bombed[index];
-              const bonus = game.board.base[index];
 
-              return (
-                <td key={col}>
-                  <GasOverlay state={hot} />
-                  {letter ? (
-                    <LetterCell
-                      letter={letter}
-                      owner={
-                        owner !== undefined ? game.players[owner] : undefined
-                      }
-                      isSelected={selectedPlayer === owner}
-                      isBombed={bombed}
-                      selectPlayer={selectPlayer}
-                    />
-                  ) : bonus ? (
-                    <BonusCell bonus={bonus} />
-                  ) : (
-                    <EmptyCell />
-                  )}
-                </td>
-              );
-            })}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+  const boxSize = (CELL_SIZE + 2) * size;
+
+  const cells: JSX.Element[] = [];
+  const importantCells: JSX.Element[] = [];
+
+  range.forEach((_, row) =>
+    range.forEach((_, col) => {
+      const x = col * (CELL_SIZE + 2);
+      const y = row * (CELL_SIZE + 2);
+
+      const index = row * size + col;
+      const letter = state.letters[index];
+      const owner = state.owners[index];
+      // const hot = state.hot[index];
+      const bombed = state.bombed[index];
+      const bonus = game.board.base[index];
+
+      // TODO: hotzone
+
+      const cell = letter ? (
+        <LetterSVG
+          x={x}
+          y={y}
+          letter={letter}
+          owner={owner === undefined ? owner : game.players[owner]}
+          isSelected={selectedPlayer === owner}
+          isBombed={bombed}
+          selectPlayer={selectPlayer}
+        />
+      ) : bonus ? (
+        <BonusSVG x={x} y={y} bonus={bonus} />
+      ) : (
+        <EmptySVG x={x} y={y} />
+      );
+
+      // Place cells which need to draw over their neighbors at the end
+      if (owner !== undefined) {
+        importantCells.push(cell);
+      } else {
+        cells.push(cell);
+      }
+    })
+  );
+
+  return (
+    <svg className={styles.board} width={boxSize} height={boxSize}>
+      {cells}
+      {importantCells}
+    </svg>
   );
 }
 
-interface GasOverlayProps {
-  state: HotZone | undefined;
+// interface GasOverlayProps {
+//   state: HotZone | undefined;
+// }
+// function GasOverlay({ state }: GasOverlayProps): JSX.Element | null {
+//   return state ? <div className={styles[state]}></div> : null;
+// }
+
+interface Coordinates {
+  x: number;
+  y: number;
 }
-function GasOverlay({ state }: GasOverlayProps): JSX.Element | null {
-  return state ? <div className={styles[state]}></div> : null;
+interface CellProps {
+  className: string;
+  background?: string;
+  content?: string;
 }
+
+function CellSVG({
+  x,
+  y,
+  className,
+  background,
+  content,
+}: CellProps & Coordinates): JSX.Element {
+  const style: any = background ? { "--cell-bg": background } : undefined;
+  const boundingSize = CELL_SIZE + 2;
+  return (
+    <svg
+      x={x}
+      y={y}
+      width={boundingSize}
+      height={boundingSize}
+      className={className}
+      style={style}
+    >
+      <rect x={1} y={1} width={CELL_SIZE} height={CELL_SIZE} />
+      {content && (
+        <text x={boundingSize / 2} y={2 + boundingSize / 2}>
+          {content}
+        </text>
+      )}
+    </svg>
+  );
+}
+
+export function EmptySVG({ x, y }: Coordinates) {
+  return <CellSVG x={x} y={y} className={styles.emptySVG} />;
+}
+
 export function EmptyCell() {
   return <div className={styles.empty} />;
 }
+
 const ownerColours = {
   0: "#68D",
   1: "#c4e",
@@ -91,6 +149,29 @@ interface LetterProps {
   isBombed?: boolean;
   selectPlayer?: (player: number | null) => void;
 }
+
+export function LetterSVG({
+  x,
+  y,
+  letter,
+  owner,
+  isSelected = false,
+}: LetterProps & Coordinates): JSX.Element {
+  const classNames = [styles.letterSVG];
+  if (isSelected) {
+    classNames.push(styles.highlight);
+  }
+  return (
+    <CellSVG
+      x={x}
+      y={y}
+      className={classNames.join(" ")}
+      background={owner && ownerColours[owner.index]}
+      content={letter.toUpperCase()}
+    />
+  );
+}
+
 export function LetterCell({
   letter,
   owner,
@@ -156,6 +237,22 @@ const bonusContentMap = {
 interface BonusProps {
   bonus: Bonus;
 }
+
+export function BonusSVG({
+  x,
+  y,
+  bonus,
+}: BonusProps & Coordinates): JSX.Element {
+  return (
+    <CellSVG
+      x={x}
+      y={y}
+      className={styles.bonusSVG}
+      content={String(bonusContentMap[bonus])}
+    />
+  );
+}
+
 export function BonusCell({ bonus }: BonusProps): JSX.Element {
   return (
     <div className={styles[bonusTypeMap[bonus]]}>{bonusContentMap[bonus]}</div>


### PR DESCRIPTION
The idea here was to have an easy-to-work on renderer that could also easily be exported as an image.

This turns out to be horribly slow to re-render, so is probably not a good approach