### PR TITLE
Move tab selection below game stepper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,22 +53,24 @@ function App() {
           </Col>
           {/* Sidebar */}
           <Col className="border-start ps-0">
-            <Tabs defaultActiveKey="steps" className="mt-3 ps-2">
-              <Tab eventKey="steps" title="Steps">
+            <Stack className="pt-2">
+              <GameStepper
+                currentStep={currentStep}
+                max={game.timeline.length - 1}
+                stepMeBack={actions.stepMeBack}
+                stepBack={actions.stepBack}
+                stepForwards={actions.stepForwards}
+                stepTo={actions.chooseStep}
+                stepMeForwards={actions.stepMeForwards}
+              />
+              <PlayerState
+                levels={game.levels}
+                {...game.timeline[currentStep].player}
+              />
+            </Stack>
+            <Tabs defaultActiveKey="players" className="mt-3 ps-2">
+              <Tab eventKey="players" title="Players">
                 <Stack className="p-2">
-                  <GameStepper
-                    currentStep={currentStep}
-                    max={game.timeline.length - 1}
-                    stepMeBack={actions.stepMeBack}
-                    stepBack={actions.stepBack}
-                    stepForwards={actions.stepForwards}
-                    stepTo={actions.chooseStep}
-                    stepMeForwards={actions.stepMeForwards}
-                  />
-                  <PlayerState
-                    levels={game.levels}
-                    {...game.timeline[currentStep].player}
-                  />
                   <PlayerList
                     players={game.players}
                     selectedPlayer={selectedPlayer}

--- a/src/Words.tsx
+++ b/src/Words.tsx
@@ -4,7 +4,7 @@ import Button from "react-bootstrap/Button";
 
 // This feels like a hack, but the CSS to make it relative seemed even more
 // complicated.
-const approxGridHeight = 780;
+const approxGridHeight = 580;
 
 interface WordsProps {
   timeline: Array<{


### PR DESCRIPTION
re: the comment already in `Words.tsx`

there's probably a combination of flex and parent containers that works, but I couldn't figure it out either. Feels like it should just work... There's the column flex container with 3 items: game stepper, tab navigation, and tab content. If you get the tab content to render at fixed height that's calculated by the flex container, then the word list should just overflow, but it doesn't because tab content always calculates height from its children instead it seems...